### PR TITLE
Regex problem with perl 5.26 fixed. 

### DIFF
--- a/tools/Modsec2LRW.pm
+++ b/tools/Modsec2LRW.pm
@@ -980,7 +980,7 @@ sub translate_macro {
 	my ($string) = @_;
 
 	# grab each macro and replace it with its lookup equivalent
-	for my $macro ($string =~ m/%{([^}]+)}/g) {
+	for my $macro ($string =~ m/%\{([^}]+)\}/g) {
 		my ($key, $specific) = split /\./, $macro;
 		my $replacement;
 


### PR DESCRIPTION
https://stackoverflow.com/questions/63384159/how-to-fix-unescaped-left-brace-in-regex-is-illegal-here-in-regex-error